### PR TITLE
enable DNSMASQ and DHCP services

### DIFF
--- a/playbooks/roles/dhcp/handlers/main.yml
+++ b/playbooks/roles/dhcp/handlers/main.yml
@@ -19,3 +19,4 @@
   systemd:
     name: dhcpd
     state: restarted
+    enabled: yes

--- a/playbooks/roles/dhcp/tasks/configure.yml
+++ b/playbooks/roles/dhcp/tasks/configure.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 ### 
 ---
-# configure ntp
+# configure DHCP
 
 - name: Open ports in the firewall
   become: true
@@ -51,4 +51,10 @@
     src: dhcpd.conf.j2
     dest: /etc/dhcp/dhcpd.conf
   notify: restart DHCP
+
+- name: Enable DHCP Service 
+  become: true
+  systemd:
+    name: dhcpd
+    enabled: yes
 

--- a/playbooks/roles/dns/handlers/main.yml
+++ b/playbooks/roles/dns/handlers/main.yml
@@ -19,3 +19,4 @@
   systemd:
     state: restarted
     name: dnsmasq
+    enabled: yes

--- a/playbooks/roles/dns/tasks/configure.yml
+++ b/playbooks/roles/dns/tasks/configure.yml
@@ -51,3 +51,10 @@
     src: hosts.j2
     dest: /etc/hosts
   notify: Restart DNS Services
+
+- name: Enable DNS Service
+  become: true
+  systemd:
+    name: dnsmasq
+    enabled: yes
+


### PR DESCRIPTION
Make sure dnsmasq and dhcp services are restarted upon a reboot of the machine hosting these services