### PR TITLE
Changes to enable RHEL worker scaling in OCP 4.2

### DIFF
--- a/group_vars/all/vars.yml.sample
+++ b/group_vars/all/vars.yml.sample
@@ -16,8 +16,9 @@
 
 ---
 #
-# Openshift 4.1 artifacts
+# OpenShift 4.X artifacts
 #
+ocp_version: 4.2                                                # Version of OpenShift being deployed
 local_home: "{{ lookup('env','HOME') }}"                        # Local user's HOME directory
 install_dir: "{{ local_home }}/.ocp"                            # OCP installation dir
 ocp_installer_path: '{{ local_home }}/kits/openshift-install'   # Path to the OCP installer
@@ -52,7 +53,7 @@ dns_servers: ['10.10.173.1','10.10.173.31']                     # DNS servers in
 # folders, templates and OVAs, templates are created using the corresponding OVA if they cannot be found (and only if they cannot be found)
 #
 support_folder: 'hpeSupport'                                    # Folder for non-OCP VMs and templates (created if needed)
-master_ova_path: '{{ local_home }}/kits/rhcos-4.2.0-x86_64-vmware.ova'          # Path to RHCOS OVA (file is expected to be there)
+master_ova_path: '{{ local_home }}/kits/rhcos-{{ ocp_version }}.0-x86_64-vmware.ova'          # Path to RHCOS OVA (file is expected to be there)
 worker_ova_path: '{{ master_ova_path }}'                        # Path to the OVA file used to create the VM template for OCP worker nodes
 support_ova_path: '{{ local_home }}/kits/hpe-rhel760.ova'       # Path to the OVA file used to create the VM template for support  machines (LBs etc)
 master_template: hpe-rhcos                                      # VMware template name for OCP master nodes

--- a/playbooks/roles/rhelworker/tasks/configure.yml
+++ b/playbooks/roles/rhelworker/tasks/configure.yml
@@ -56,7 +56,7 @@
     name:
       - rhel-7-server-rpms
       - rhel-7-server-extras-rpms
-      - rhel-7-server-ose-4.2-rpms
+      - 'rhel-7-server-ose-{{ ocp_version }}-rpms'
     purge: True
   when:
     - ansible_distribution == 'RedHat'

--- a/playbooks/roles/rhelworker/tasks/configure.yml
+++ b/playbooks/roles/rhelworker/tasks/configure.yml
@@ -56,7 +56,7 @@
     name:
       - rhel-7-server-rpms
       - rhel-7-server-extras-rpms
-      - rhel-7-server-ose-4.1-rpms
+      - rhel-7-server-ose-4.2-rpms
     purge: True
   when:
     - ansible_distribution == 'RedHat'

--- a/playbooks/roles/rhelworker/vars/main.yml
+++ b/playbooks/roles/rhelworker/vars/main.yml
@@ -15,4 +15,4 @@
 ###
 
 ---
-# vars file for rhelworker
+ocp_version: 4.2                                                # Version of OpenShift being deployed


### PR DESCRIPTION
This change, along with cloning an OCP 4.2 version of the OpenShift Ansible repository, allows RHEL workers to scale in OCP 4.2.  The updated OpenShift Ansible repository instructions will be updated separately in the documentation repository.