### PR TITLE
make efk_channel mandatory

### DIFF
--- a/playbooks/roles/efk/defaults/main.yml
+++ b/playbooks/roles/efk/defaults/main.yml
@@ -15,7 +15,7 @@
 ###
 
 ---
-efk_channel: "preview"               # templates to use if no OCP version if specified
+efk_channel: "invalid"               # efk_channel must be configured in group_vars/all/vars.yml
 efk_es_pv_size: '200G'               # Size of Persistent Volume used for Elasticsearch data
 efk_es_pv_storage_class: 'thin'      # Storage class name used for Elasticsearch data
 efk_profile: small                   # elasic search sizing: small = 2Gi RAM and 200m core of CPU, 'large' = 16Gi of RAM and 1 CPU core

--- a/release_notes.md
+++ b/release_notes.md
@@ -120,7 +120,7 @@ The following variables can be used to deploy the EFK stack. The `#` sign in fro
 
 | Variable                   | Default value | Description                                                  |
 | -------------------------- | ------------- | ------------------------------------------------------------ |
-| #`efk_channel`             | `"4.2"`       | The "channel" to use in the Operator Hub for the EFK stack. Must be "preview" when deploying on OCP 4.1 |
+| `efk_channel`              |               | Mandatory. "preview" when deploying on OCP 4.1i, "4.2: when deploygin OCP 4.2 |
 | #`efk_es_pv_size`          | `200G`        | Size of the persistent volume which will holds the elasticsearch data. |
 | #`efk_es_pv_storage_class` | `thin`        | This is the name of the storage class to use for persistent storage. |
 | #`efk_profile`             | `small`       | `small` or `large`. the `small` profile deploys a single instance of elasticsearch and a single instance of kibana. There is no redundancy of the elasticsearch data. Also the elasticsearch resource limits are set to 100m core and 2Gi or RAM. |

--- a/release_notes.md
+++ b/release_notes.md
@@ -120,7 +120,7 @@ The following variables can be used to deploy the EFK stack. The `#` sign in fro
 
 | Variable                   | Default value | Description                                                  |
 | -------------------------- | ------------- | ------------------------------------------------------------ |
-| `efk_channel`              |               | Mandatory. "preview" when deploying on OCP 4.1i, "4.2: when deploygin OCP 4.2 |
+| `efk_channel`              |               | Mandatory. "preview" when deploying on OCP 4.1, "4.2: when deploying OCP 4.2 |
 | #`efk_es_pv_size`          | `200G`        | Size of the persistent volume which will holds the elasticsearch data. |
 | #`efk_es_pv_storage_class` | `thin`        | This is the name of the storage class to use for persistent storage. |
 | #`efk_profile`             | `small`       | `small` or `large`. the `small` profile deploys a single instance of elasticsearch and a single instance of kibana. There is no redundancy of the elasticsearch data. Also the elasticsearch resource limits are set to 100m core and 2Gi or RAM. |


### PR DESCRIPTION
efk_channel mandatory as providing a default might see people use a default that does not work with the version of OCP they install