### PR TITLE
Proxy

### DIFF
--- a/group_vars/all/vars.yml.sample
+++ b/group_vars/all/vars.yml.sample
@@ -144,3 +144,10 @@ sysdig_k8s_cluster_name: "{{ cluster_name }}"               # allows you to view
 #- 10.10.173.109
 #- 10.10.173.110
 #- 10.10.173.111
+
+#
+# Proxy Configuration
+#
+#http_proxy: "http://10.12.7.21:8080"
+#https_proxy: "http://10.12.7.21:8080"
+#no_proxy: "localhost,.{{ domain_name }},{{ dhcp_subnet }},{{ vcenter_hostname }}"

--- a/group_vars/all/vars.yml.sample
+++ b/group_vars/all/vars.yml.sample
@@ -148,6 +148,6 @@ sysdig_k8s_cluster_name: "{{ cluster_name }}"               # allows you to view
 #
 # Proxy Configuration
 #
-#http_proxy: "http://10.12.7.21:8080"
-#https_proxy: "http://10.12.7.21:8080"
+#http_proxy: "http://web-proxy.hpecloud.org:8080"
+#https_proxy: "http://web-proxy.hpecloud.org:8080"
 #no_proxy: "localhost,.{{ domain_name }},{{ dhcp_subnet }},{{ vcenter_hostname }}"

--- a/group_vars/all/vault.yml.sample
+++ b/group_vars/all/vault.yml.sample
@@ -24,4 +24,4 @@ vault:
   pull_secret: '...  replace with your pull secret  ...'
   ssh_key: '...  replace with your ssh public key  ...'
   ldap_bind_user_password: 'password of LDAP user used for binding with LDAP'
-  sysdig_access_key: 'your sysdig access key here
+  sysdig_access_key: 'your sysdig access key here'

--- a/playbooks/roles/cloudinit/templates/cloud_init_users.yml.j2
+++ b/playbooks/roles/cloudinit/templates/cloud_init_users.yml.j2
@@ -25,3 +25,15 @@ users:
     lock_passwd: true
     ssh_authorized_keys:
       - {{ ssh_key }}
+{% if http_proxy is defined %}
+write_files:
+  - content: |
+      http_proxy="{{ http_proxy }}"
+      {% if https_proxy is defined %}https_proxy="{{ https_proxy }}"{% endif %}
+
+      {% if no_proxy is defined %}no_proxy="{{ no_proxy }}"{% endif %}
+
+    owner: root:root
+    path: /etc/environment
+    permissions: '0644'
+{% endif %}

--- a/playbooks/roles/csr/tasks/approve_node_csr.yml
+++ b/playbooks/roles/csr/tasks/approve_node_csr.yml
@@ -61,19 +61,6 @@
   environment:
     KUBECONFIG: "{{ install_dir }}/auth/kubeconfig"
 
-- name: Query node
-  delegate_to: localhost
-  k8s_facts:
-    kind: node
-    field_selectors:
-      metadata.name={{ inventory_hostname }}
-  register: res
-  environment:
-    KUBECONFIG: "{{ install_dir }}/auth/kubeconfig"
-  delay: 5
-  retries: "{{ csr_wait_for_node_retries }}"
-  until: res.resources | count > 0
-
 - name: Approve node CSR
   shell: >
     count=0;

--- a/playbooks/roles/ocpinstaller/templates/install-config.yaml.j2
+++ b/playbooks/roles/ocpinstaller/templates/install-config.yaml.j2
@@ -16,6 +16,14 @@
 
 apiVersion: v1
 baseDomain: {{ domain_name }}
+{% if http_proxy is defined %}
+proxy:
+  httpProxy: "{{ http_proxy }}"
+  {% if https_proxy is defined %}httpsProxy: "{{ https_proxy }}"{% endif %}
+
+  {% if no_proxy is defined %}noProxy: "{{ no_proxy }}"{% endif %}
+
+{% endif %}
 compute:
 - name: worker
   hyperthreading: Enabled

--- a/release_notes.md
+++ b/release_notes.md
@@ -405,8 +405,8 @@ Three new variables were added to the `group_vars/all/vars.yml` file to add prox
 
 | Variable                 | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `http_proxy`    | Hostname or IP address of the HTTP proxy server and the proxy port number separated by a colon.  For example: "http://10.12.7.21:8080". |
-| `https_proxy`    | Hostname or IP address of the HTTPS proxy server and the proxy port number separated by a colon. Typically this value is set identical to `http_proxy`. For example: "http://10.12.7.21:8080". |
+| `http_proxy`    | Hostname or IP address of the HTTP proxy server and the proxy port number separated by a colon.  For example: "http://web-proxy.hpecloud.org:8080". |
+| `https_proxy`    | Hostname or IP address of the HTTPS proxy server and the proxy port number separated by a colon. Typically this value is set identical to `http_proxy`. For example: "http://web-proxy.hpecloud.org:8080". |
 | `no_proxy` | A comma-separated list of hostnames, IP addresses, or network ranges that should bypass the proxy server. By default the list includes: localhost, the configured domain name used to deploy the OCP cluster (`domain_name` variable), the DHCP subnet CIDR (`dhcp_subnet` variable), and the vCenter hostname (`vcenter_hostname` variable). This value can be customized to include additional values required by the customer environment. |
 
 By default all three variables are commented-out, which is the proper configuration in environments where no proxy server is needed to reach the Internet.
@@ -424,5 +424,5 @@ installonly_limit=3
 clean_requirements_on_remove=True
 best=False
 skip_if_unavailable=True
-proxy=http://10.12.7.21:8080
+proxy=http://web-proxy.hpecloud.org:8080
 ```

--- a/release_notes.md
+++ b/release_notes.md
@@ -394,3 +394,35 @@ vsphere-csi-node-lnhr7     3/3     Running   0          8h    10.15.152.214   hp
 
 
 You should have one vsphere-csi-node pod running on each worker node.
+
+### Proxy Support
+
+The playbooks now support deploying the OCP 4.2 solution in environments that require a proxy server to reach the open Internet. The default configuration assumes there is no proxy server in the environment. Both the solution playbook variables and the Ansible node must be properly configured for proxy support.
+
+#### Playbook Variables
+
+Three new variables were added to the `group_vars/all/vars.yml` file to add proxy support:
+
+| Variable                 | Description                                                  |
+| ------------------------ | ------------------------------------------------------------ |
+| `http_proxy`    | Hostname or IP address of the HTTP proxy server and the proxy port number separated by a colon.  For example: "http://10.12.7.21:8080". |
+| `https_proxy`    | Hostname or IP address of the HTTPS proxy server and the proxy port number separated by a colon. Typically this value is set identical to `http_proxy`. For example: "http://10.12.7.21:8080". |
+| `no_proxy` | A comma-separated list of hostnames, IP addresses, or network ranges that should bypass the proxy server. By default the list includes: localhost, the configured domain name used to deploy the OCP cluster (`domain_name` variable), the DHCP subnet CIDR (`dhcp_subnet` variable), and the vCenter hostname (`vcenter_hostname` variable). This value can be customized to include additional values required by the customer environment. |
+
+By default all three variables are commented-out, which is the proper configuration in environments where no proxy server is needed to reach the Internet.
+
+#### Ansible Node
+
+The Ansible node should be configured to match the proxy requirements of the customer environment. The only `required` proxy configuration on the Ansible node is to ensure the solution playbooks can install any necessary software packages, such as a local HTTP server. This can be done by either adding a proxy entry to the `/etc/dnf/dnf.conf` file or by setting system-wide proxy settings in the `/etc/environment` file.
+
+An example of configuring a proxy server in the `/etc/dnf/dnf.conf` file is:
+
+```bash
+[main]
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=True
+best=False
+skip_if_unavailable=True
+proxy=http://10.12.7.21:8080
+```


### PR DESCRIPTION
Here is the first pass at proxy support.  Thanks to Christophe for his help on this.

A couple of notes:

1) In my testing I didn't have to set any system-wide proxy setting on my Ansible node.  The only configuration change I made was to add a "proxy" line to the /etc/dnf/dnf.conf file.  That change is only needed because the playbooks\roles\prepare\tasks\provision.yml playbook installs an HTTP server on the Ansible node.

2) I took a shot at automating the configuration of the no_proxy variable in the vars.yml file.  These settings worked fine in my testing.  Presumably the customer would need to make any modifications to all three proxy variables to match their environment, but I liked the idea of providing a starting point for the no_proxy variable using previously configured settings.

3) The way the playbooks work now, if the proxy variables are commented out of the vars.yml file, no changes are made to the template files.  I've tested this and confirmed.  For this reason, I don't think we need to do a full re-test of everything in the non-proxy environment.  I did an OCP deployment in the non-proxy setup and the cluster came up fine, and I verified both the cloud_init_users.yml and install-config.yaml files are unchanged in the non-proxy environment.  Seems overkill to re-test everything if none of the configuration files/templates contents are changing.

4) So far here is what I've tested in the proxy environment:
- OCP cluster deploy
- RHCOS worker scaling
- RHEL worker scaling
- Monitoring with persistent storage
- EFK logging stack

All work in the proxy environment.  I have not yet tested the following:
- CSI storage
- LDAP
- Sysdig

I will start testing those, but wanted to at least push a copy of the code for others to play with if they wish.