### PR TITLE
fix issues with k8s_facts

### DIFF
--- a/playbooks/roles/csr/tasks/approve_node_csr.yml
+++ b/playbooks/roles/csr/tasks/approve_node_csr.yml
@@ -61,19 +61,6 @@
   environment:
     KUBECONFIG: "{{ install_dir }}/auth/kubeconfig"
 
-- name: Query node
-  delegate_to: localhost
-  k8s_facts:
-    kind: node
-    field_selectors:
-      metadata.name={{ inventory_hostname }}
-  register: res
-  environment:
-    KUBECONFIG: "{{ install_dir }}/auth/kubeconfig"
-  delay: 5
-  retries: "{{ csr_wait_for_node_retries }}"
-  until: res.resources | count > 0
-
 - name: Approve node CSR
   shell: >
     count=0;

--- a/playbooks/roles/ocpinstaller/tasks/bootstrap_complete.yml
+++ b/playbooks/roles/ocpinstaller/tasks/bootstrap_complete.yml
@@ -56,7 +56,9 @@
     name: image-registry
   register: res
   retries: "{{ ( ocpinstaller_clusteroperators_timeout / 10 ) | int }}"
-  until: res.resources | count > 0
+  until: 
+  - res.resources is defined
+  - res.resources | count > 0
   environment:
     KUBECONFIG: "{{ install_dir }}/auth/kubeconfig"
 


### PR DESCRIPTION
- Fix the issue seen with ocp4.2.9 and ansible 2.8.5 where the loop waiting for the creation of the image-registry operator fails 
- fix the issue where k8s_facts used with a field selector in scales.yml always return an empty list of resources