### PR TITLE
Updated timeout/retry

### DIFF
--- a/playbooks/roles/wordpress/tasks/validate.yml
+++ b/playbooks/roles/wordpress/tasks/validate.yml
@@ -44,8 +44,8 @@
   set_fact:
     app_url: "http://{{ ans.stdout }}"
 
-- name: Wait for WordPress pods to become ready
-  shell: "kubectl wait --namespace={{ wp_proj_name }} --for=condition=Ready pods --selector tier=frontend --timeout=60s"
+- name: Wait for WordPress pods to become ready (maximum 5 minutes)
+  shell: "kubectl wait --namespace={{ wp_proj_name }} --for=condition=Ready pods --selector tier=frontend --timeout=5m"
   register: res
   environment:
     KUBECONFIG: "{{ install_dir }}/auth/kubeconfig"
@@ -64,3 +64,7 @@
     headers:
       Host: "{{ app_hostname }}"
     status_code: 302
+  retries: 10
+  delay: 2
+  register: result
+  until: result.status == 302


### PR DESCRIPTION
** Small timeout changes, only 1 reviewer requested **

- Increased maximum time to wait for Pods to start
- Add retry look for trying to connect to WordPress webserver
  - Validated retry by deleting route before running validation - then adding route back in the middle of connectivity test loops:

...
TASK [wordpress : Validate WordPress Webserver access] *****************************************************************************************
Friday 13 December 2019  20:10:05 -0500 (0:00:02.396)       0:00:03.730 *******
FAILED - RETRYING: Validate WordPress Webserver access (10 retries left).
FAILED - RETRYING: Validate WordPress Webserver access (9 retries left).
FAILED - RETRYING: Validate WordPress Webserver access (8 retries left).
FAILED - RETRYING: Validate WordPress Webserver access (7 retries left).
FAILED - RETRYING: Validate WordPress Webserver access (6 retries left).
FAILED - RETRYING: Validate WordPress Webserver access (5 retries left).
ok: [localhost]

TASK [wordpress : include_tasks] ***************************************************************************************************************
Friday 13 December 2019  20:10:24 -0500 (0:00:19.425)       0:00:23.155 *******
skipping: [localhost]
